### PR TITLE
feat: `assert_unchecked!` and `unreachable_unchecked!` work in const context

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -277,7 +277,7 @@ mod debug_assertion_tests {
 
     #[test]
     #[cfg(debug_assertions)]
-    #[should_panic(expected = "assertion failed: `(left == right)`")]
+    #[should_panic(expected = "assertion `left == right` failed\n")]
     fn test_assert_eq_fail_no_message() {
         unsafe { assert_eq_unchecked!(NoCopy(0), NoCopy(1)) }
     }
@@ -308,7 +308,7 @@ mod debug_assertion_tests {
 
     #[test]
     #[cfg(debug_assertions)]
-    #[should_panic(expected = "assertion failed: `(left != right)`")]
+    #[should_panic(expected = "assertion `left != right` failed\n")]
     fn test_assert_ne_fail_no_message() {
         unsafe { assert_ne_unchecked!(NoCopy(0), NoCopy(0)) }
     }


### PR DESCRIPTION
It's useful to be able use `assert_unchecked!` and `unreachable_unchecked!` in const functions.

Obviously, there's not much point in a function which is *only* used in const context, as a plain `assert!` will be evaluated at compile time anyway. But it can be helpful in const functions which *may or may not* be called from const/non-const context.

`core::hint::unreachable_unchecked` has been supported in const contexts since Rust 1.57.0. `assert!` and `unreachable!` macros have also been usable in const contexts for some time (can't find exact reference for what version that happened in).

So only thing preventing `assert_unchecked!` and `unreachable_unchecked!` in const context is the non-constness of the `__needs_unsafe` functions. This PR makes those functions const, which solves the problem.

I don't believe this would be a breaking change in any version of Rust. In older Rust versions, the macros just won't be usable in const contexts, as before.

Note: `assert_eq!` and `assert_ne!` remain unsupported in const contexts in stable Rust. So have not made any change to `assert_eq_unchecked` or `assert_ne_unchecked` - it's not possible to make them const-friendly without a lot of changes.

This PR also includes #1 so that the tests pass.